### PR TITLE
Fix bug for starting training on custom dataset

### DIFF
--- a/run_training.py
+++ b/run_training.py
@@ -58,7 +58,7 @@ def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, m
     desc = 'stylegan2'
 
     desc += '-' + dataset
-    dataset_args = EasyDict(tfrecord_dir=dataset)
+    dataset_args = EasyDict(tfrecord_dir=data_dir)
 
     assert num_gpus in [1, 2, 4, 8]
     sc.num_gpus = num_gpus


### PR DESCRIPTION
Confusion in `dataset` and `data_dir`:

- `dataset` is just the name of the dataset you are training not anything related to directory
- `data_dir` is directory containing `tfrecord files`

Fixed bug which prevents training on custom dataset