### PR TITLE
Potential bug in gradient accumulation?

### DIFF
--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -304,8 +304,7 @@ def training_loop(
                 for _round in rounds:
                     tflib.run(data_fetch_op, feed_dict)
                     tflib.run(D_train_op, feed_dict)
-                if run_D_reg:
-                    for _round in rounds:
+                    if run_D_reg:
                         tflib.run(D_reg_op, feed_dict)
 
         # Perform maintenance tasks once per tick.


### PR DESCRIPTION
For the gradient accumulation case, currently the regularization for the discriminator performs multiple rounds on the same batch of images, instead of averaging the regularization loss over multiple different batches (as is done for the standard discriminator loss). 
Is this a bug or is it arranged this way intentionally?

Thanks!