### PR TITLE
cleaning unnecessary pip cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@
 
 FROM tensorflow/tensorflow:1.15.0-gpu-py3
 
-RUN pip install scipy==1.3.3
-RUN pip install requests==2.22.0
-RUN pip install Pillow==6.2.1
+RUN pip install --no-cache-dir scipy==1.3.3
+RUN pip install --no-cache-dir requests==2.22.0
+RUN pip install --no-cache-dir Pillow==6.2.1


### PR DESCRIPTION
https://pip.pypa.io/en/stable/reference/pip_install/#caching

It's almost 30MB difference in a 3GB docker image:)
But it's safe to use and I can't think of a situation where pip cache in creating this image is needed.