### PR TITLE
Added preprocess and reshape image dataset function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-/.stylegan2-cache/
-__pycache__/

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ python run_projector.py project-generated-images --network=gdrive:networks/style
 python run_projector.py project-real-images --network=gdrive:networks/stylegan2-car-config-f.pkl \
   --dataset=car --data-dir=~/datasets
 ```
+## Resizing images to be of uniform size
+The StyleGan2 model requires all images in the dataset to be of uniform size , when using a custom dataset this may cause a frequent error because all the images in the dataset may not be of the same shape. To resize all images in your dataset to be of uniform shape execute the below command in your terminal or console. The arguments needed to be passed are , image_dataset_directory ,  image save directory  , image_size. The image size should be a single integer such as 128,256,512 and in addition the number of channels are by default set to 3.
+
+```
+> python preprocess_image.py image_dataset_directory/  resized_image_save_directory/ 256
+```
 
 ## Training networks
 

--- a/preprocess_images.py
+++ b/preprocess_images.py
@@ -1,0 +1,62 @@
+import numpy as np 
+import sys
+import tensorflow as tf
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+import pandas as pd
+import matplotlib.pyplot as plt
+import PIL
+from PIL import Image
+import os
+import scipy 
+from scipy import ndimage
+import tqdm
+from tqdm import tqdm
+
+def preprocess_images(image_dir,save_dir,image_size,image_channels=3,extension=".png"):
+    print("processing....")
+    training_data = []
+    if(not os.path.exists(save_dir)):
+        os.mkdir(save_dir)
+    if(os.path.exists(image_dir)):
+        print(len(os.listdir(image_dir))," images to resized and processed")
+        print("\n Processing images....")
+        for index ,filename in enumerate(tqdm(os.listdir(image_dir))):
+        
+            path = os.path.join(image_dir,filename)
+            image = Image.open(path).resize((image_size,image_size),Image.ANTIALIAS)
+            image_arr  = np.asarray(image)
+            if(image_arr.shape == (image_size,image_size,image_channels)):
+                training_data.append(image_arr)
+                im = Image.fromarray(image_arr)
+                im.save(save_dir+"/image_"+str(index)+extension)
+        print(training_data[0].shape)
+        training_data = np.reshape(training_data,(-1,image_size,image_size,image_channels))
+        training_data = training_data.astype(np.float32)
+        print("Successfully processed and reshaped images")
+    else:
+        print("Image data directory does not exist")
+        print("\nPlease check if specified training data directory path is correct")
+    return None
+
+
+try :
+    image_dir = sys.argv[1] #Relative path of image directory
+    save_dir  = sys.argv[2] # Relative path of save directory
+    image_shape = int(sys.argv[3]) #image shape an integer
+
+
+    print("Image source directory : ",os.path.join(os.getcwd(),image_dir))
+    print("Saving processed images in  : ",os.path.join(os.getcwd()),save_dir)
+    print(f"Resized image shape : ({image_shape},{image_shape},{3})")
+except IndexError as error:
+    print("Error")
+    if(len(sys.argv) == 0):
+        print("No parameters are specified")
+    elif(len(sys.argv) == 1):
+        print("Save directory , image shape and image_channel parameters are not specified")
+    elif(len(sys.argv) == 2):
+        print("image shape and image channel parameters not specified")
+    elif(len(sys.argv) == 3):
+        print("image channel parameter not specified")
+
+preprocess_images(image_dir=image_dir,save_dir=save_dir,image_size=image_shape)


### PR DESCRIPTION
The StyleGAN2 model requires all images in the dataset to be of uniform size , currently this pre-processing stage has to be done manually , I have developed a helper function which can reshape all images in a given source directory to be of the shape that can be specified and save it in another specified directory.In addition I have also updated the Readme.md to include this change and show how the command should be executed in the terminal.

The Pillow(PIL) library is used for reshaping the images and tqdm is used for visualizing the progress.
![style_gan2](https://user-images.githubusercontent.com/56014038/92999115-1527e380-f53c-11ea-953d-f6e8ee59fbaf.PNG)
![style_gan2_completed](https://user-images.githubusercontent.com/56014038/92999119-19540100-f53c-11ea-9ad4-6d1124c0bb41.PNG)
