### PR TITLE
Add Weights and Biases Experiment tracking

### DIFF
--- a/dnnlib/tflib/autosummary.py
+++ b/dnnlib/tflib/autosummary.py
@@ -187,5 +187,6 @@ def save_summaries(file_writer, global_step=None):
             file_writer.add_summary(layout)
         with tf.device(None), tf.control_dependencies(None):
             _merge_op = tf.summary.merge_all()
-
-    file_writer.add_summary(_merge_op.eval(), global_step)
+    _merge_op_eval = _merge_op.eval()
+    file_writer.add_summary(_merge_op_eval, global_step)
+    return _merge_op_eval

--- a/dnnlib/wandb_utils.py
+++ b/dnnlib/wandb_utils.py
@@ -1,25 +1,19 @@
+import imghdr
+
 import wandb
 from wandb.integration.tensorboard import tf_summary_to_dict
 
 class WandbLogger():
-    def __init__(self, project, name, config, group=None):
-        self.run = wandb.init(project=project, name=name, config=config, group=group) if not wandb.run else wandb.run
+    def __init__(self, project, name, config, job_type=None):
+        self.run = wandb.init(project=project, name=name, config=config, job_type=job_type) if not wandb.run else wandb.run
         self.log_dict = {}
-
-    def log_scalar(self, log_dict):
-        for key, value in log_dict.items():
-            self.log_dict[key] = value
             
     def log_tf_summary(self, summary):
         tf_log_dict = wandb.integration.tensorboard.tf_summary_to_dict(summary)
-        if tf_log_dict is None:
-            return
-        for key, value in tf_log_dict.items():
-            self.log_dict[key] = value
-    
-    def log_image(self, path, name):
-        self.log_dict[name] = wandb.Image(path)
-    
+        if tf_log_dict:
+            for key, value in tf_log_dict.items():
+                self.log_dict[key] = value
+                
     def log_model_artifact(self, path, step):
         model_artifact = wandb.Artifact('run_'+wandb.run.id+'_checkpoints', type='model', metadata={'cur_nimg': step})
         model_artifact.add_file(path, name='network-snapshot-%06d.pkl' % (step))
@@ -28,3 +22,15 @@ class WandbLogger():
     def flush(self):
         wandb.log(self.log_dict)
         self.log_dict = {}
+    
+    def log(self, log_dict, flush=False):
+        for key, value in log_dict.items():
+            if imghdr.what(value): # Check if the value is an image
+                self.log_dict[key] = wandb.Image(value)
+            else:
+                self.log_dict[key] = value
+        if flush:
+            self.flush()
+            
+
+

--- a/dnnlib/wandb_utils.py
+++ b/dnnlib/wandb_utils.py
@@ -1,0 +1,30 @@
+import wandb
+from wandb.integration.tensorboard import tf_summary_to_dict
+
+class WandbLogger():
+    def __init__(self, project, name, config, group=None):
+        self.run = wandb.init(project=project, name=name, config=config, group=group) if not wandb.run else wandb.run
+        self.log_dict = {}
+
+    def log_scalar(self, log_dict):
+        for key, value in log_dict.items():
+            self.log_dict[key] = value
+            
+    def log_tf_summary(self, summary):
+        tf_log_dict = wandb.integration.tensorboard.tf_summary_to_dict(summary)
+        if tf_log_dict is None:
+            return
+        for key, value in tf_log_dict.items():
+            self.log_dict[key] = value
+    
+    def log_image(self, path, name):
+        self.log_dict[name] = wandb.Image(path)
+    
+    def log_model_artifact(self, path, step):
+        model_artifact = wandb.Artifact('run_'+wandb.run.id+'_checkpoints', type='model', metadata={'cur_nimg': step})
+        model_artifact.add_file(path, name='network-snapshot-%06d.pkl' % (step))
+        wandb.log_artifact(model_artifact)
+
+    def flush(self):
+        wandb.log(self.log_dict)
+        self.log_dict = {}

--- a/run_projector.py
+++ b/run_projector.py
@@ -23,7 +23,6 @@ from dnnlib.wandb_utils import WandbLogger
 wandb_logger = WandbLogger(project='stylegan2', name='generation', config=None, job_type='generation')
 
 def project_image(proj, targets, png_prefix, num_snapshots):
-    print("proj.num_steps==>",basename(png_prefix))
     snapshot_steps = set(proj.num_steps - np.linspace(0, proj.num_steps, num_snapshots, endpoint=False, dtype=int))
     misc.save_image_grid(targets, png_prefix + 'target.png', drange=[-1,1])
     proj.start(targets)

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -138,13 +138,13 @@ def training_loop(
     tflib.init_tf(tf_config)
     num_gpus = dnnlib.submit_config.num_gpus
     wandb_logger = WandbLogger(project='stylegan2', name='train-'+dataset_args['tfrecord_dir'], 
-                   config=dnnlib.submit_config,group="training")
+                   config=dnnlib.submit_config, job_type="training")
 
     # Load training set.
     training_set = dataset.load_dataset(data_dir=dnnlib.convert_path(data_dir), verbose=True, **dataset_args)
     grid_size, grid_reals, grid_labels = misc.setup_snapshot_image_grid(training_set, **grid_args)
     misc.save_image_grid(grid_reals, dnnlib.make_run_dir_path('reals.png'), drange=training_set.dynamic_range, grid_size=grid_size)
-    wandb_logger.log_image(dnnlib.make_run_dir_path('reals.png'), 'Real Samples')
+    wandb_logger.log({'Real Samples':dnnlib.make_run_dir_path('reals.png')})
     
     # Construct or load networks.
     with tf.device('/gpu:0'):
@@ -165,7 +165,7 @@ def training_loop(
     grid_latents = np.random.randn(np.prod(grid_size), *G.input_shape[1:])
     grid_fakes = Gs.run(grid_latents, grid_labels, is_validation=True, minibatch_size=sched.minibatch_gpu)
     misc.save_image_grid(grid_fakes, dnnlib.make_run_dir_path('fakes_init.png'), drange=drange_net, grid_size=grid_size)
-    wandb_logger.log_image(dnnlib.make_run_dir_path('fakes_init.png'), 'Initial Fakes')
+    wandb_logger.log({'Initial Fakes': dnnlib.make_run_dir_path('fakes_init.png')})
     
     # Setup training inputs.
     print('Building TensorFlow graph...')
@@ -340,7 +340,7 @@ def training_loop(
             if image_snapshot_ticks is not None and (cur_tick % image_snapshot_ticks == 0 or done):
                 grid_fakes = Gs.run(grid_latents, grid_labels, is_validation=True, minibatch_size=sched.minibatch_gpu)
                 misc.save_image_grid(grid_fakes, dnnlib.make_run_dir_path('fakes%06d.png' % (cur_nimg // 1000)), drange=drange_net, grid_size=grid_size)
-                wandb_logger.log_image(dnnlib.make_run_dir_path('fakes%06d.png' % (cur_nimg // 1000)), 'fake')
+                wandb_logger.log({'fake': dnnlib.make_run_dir_path('fakes%06d.png' % (cur_nimg // 1000))})
             if network_snapshot_ticks is not None and (cur_tick % network_snapshot_ticks == 0 or done):
                 pkl = dnnlib.make_run_dir_path('network-snapshot-%06d.pkl' % (cur_nimg // 1000))
                 misc.save_pkl((G, D, Gs), pkl)

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -15,6 +15,7 @@ from dnnlib.tflib.autosummary import autosummary
 from training import dataset
 from training import misc
 from metrics import metric_base
+from dnnlib.wandb_utils import WandbLogger
 
 #----------------------------------------------------------------------------
 # Just-in-time processing of training images before feeding them to the networks.
@@ -133,15 +134,18 @@ def training_loop(
     resume_time             = 0.0,      # Assumed wallclock time at the beginning. Affects reporting.
     resume_with_new_nets    = False):   # Construct new networks according to G_args and D_args before resuming training?
 
-    # Initialize dnnlib and TensorFlow.
+    # Initialize dnnlib, TensorFlow and WandbLogger
     tflib.init_tf(tf_config)
     num_gpus = dnnlib.submit_config.num_gpus
+    wandb_logger = WandbLogger(project='stylegan2', name='train-'+dataset_args['tfrecord_dir'], 
+                   config=dnnlib.submit_config,group="training")
 
     # Load training set.
     training_set = dataset.load_dataset(data_dir=dnnlib.convert_path(data_dir), verbose=True, **dataset_args)
     grid_size, grid_reals, grid_labels = misc.setup_snapshot_image_grid(training_set, **grid_args)
     misc.save_image_grid(grid_reals, dnnlib.make_run_dir_path('reals.png'), drange=training_set.dynamic_range, grid_size=grid_size)
-
+    wandb_logger.log_image(dnnlib.make_run_dir_path('reals.png'), 'Real Samples')
+    
     # Construct or load networks.
     with tf.device('/gpu:0'):
         if resume_pkl is None or resume_with_new_nets:
@@ -161,7 +165,8 @@ def training_loop(
     grid_latents = np.random.randn(np.prod(grid_size), *G.input_shape[1:])
     grid_fakes = Gs.run(grid_latents, grid_labels, is_validation=True, minibatch_size=sched.minibatch_gpu)
     misc.save_image_grid(grid_fakes, dnnlib.make_run_dir_path('fakes_init.png'), drange=drange_net, grid_size=grid_size)
-
+    wandb_logger.log_image(dnnlib.make_run_dir_path('fakes_init.png'), 'Initial Fakes')
+    
     # Setup training inputs.
     print('Building TensorFlow graph...')
     with tf.name_scope('Inputs'), tf.device('/cpu:0'):
@@ -335,14 +340,18 @@ def training_loop(
             if image_snapshot_ticks is not None and (cur_tick % image_snapshot_ticks == 0 or done):
                 grid_fakes = Gs.run(grid_latents, grid_labels, is_validation=True, minibatch_size=sched.minibatch_gpu)
                 misc.save_image_grid(grid_fakes, dnnlib.make_run_dir_path('fakes%06d.png' % (cur_nimg // 1000)), drange=drange_net, grid_size=grid_size)
+                wandb_logger.log_image(dnnlib.make_run_dir_path('fakes%06d.png' % (cur_nimg // 1000)), 'fake')
             if network_snapshot_ticks is not None and (cur_tick % network_snapshot_ticks == 0 or done):
                 pkl = dnnlib.make_run_dir_path('network-snapshot-%06d.pkl' % (cur_nimg // 1000))
                 misc.save_pkl((G, D, Gs), pkl)
+                wandb_logger.log_model_artifact(pkl, cur_nimg // 1000)
                 metrics.run(pkl, run_dir=dnnlib.make_run_dir_path(), data_dir=dnnlib.convert_path(data_dir), num_gpus=num_gpus, tf_config=tf_config)
 
             # Update summaries and RunContext.
             metrics.update_autosummaries()
-            tflib.autosummary.save_summaries(summary_log, cur_nimg)
+            summary = tflib.autosummary.save_summaries(summary_log, cur_nimg)
+            wandb_logger.log_tf_summary(summary)
+            wandb_logger.flush()
             dnnlib.RunContext.get().update('%.2f' % sched.lod, cur_epoch=cur_nimg // 1000, max_epoch=total_kimg)
             maintenance_time = dnnlib.RunContext.get().get_last_update_interval() - tick_time
 


### PR DESCRIPTION
This PR adds support for experiment tracking using W&B. Each part of the stylegan2 pipeline is treated as a separate process.
* ### The progress of training, projection, and generation can be accessed from the W&B dashboard.
![ezgif com-gif-maker](https://user-images.githubusercontent.com/15766192/105224338-0f45ad00-5b83-11eb-9274-669f181bcd34.gif)
* ### The model and the system metrics are also automatically logged
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/15766192/105224688-7ebb9c80-5b83-11eb-9185-0dc5145ad3b3.gif)
* ### The model checkpoints are versioned and logged as W&B artifacts as they get saved locally
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/15766192/105226554-22a64780-5b86-11eb-8d4a-7be5c9e52747.gif)
[Here's](https://wandb.ai/cayush/stylegan2?workspace=user-cayush) the link to the public dashboard used in this example.